### PR TITLE
Updated proxyquire to version 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-sourcemaps": "1.5.2",
     "istanbul": "0.3.21",
     "jasmine": "2.3.2",
-    "proxyquire": "1.7.2",
+    "proxyquire": "1.7.3",
     "rimraf": "2.4.3",
     "source-map-support": "0.3.2"
   },


### PR DESCRIPTION
:rocket:

proxyquire just published version 1.7.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [0a91f0e](https://github.com/thlorenz/proxyquire/commit/0a91f0e5cc4d9df2c8ba5f97f90d77d69e898f37): 1.7.3
- [07a4d0f](https://github.com/thlorenz/proxyquire/commit/07a4d0f518d8bf9dc1353a1b615ffeb03fef6109): Update fill-keys to latest to handle prototype-less fns

See the [full diff](https://github.com/thlorenz/proxyquire/compare/2f6f0066b4a4783aadbb5eacd7c529c695fca808...0a91f0e5cc4d9df2c8ba5f97f90d77d69e898f37).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>