### PR TITLE
chore(package): mv @babel/runtime from devdeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@babel/plugin-transform-react-constant-elements": "7.2.0",
     "@babel/plugin-transform-runtime": "7.2.0",
     "@babel/preset-env": "7.2.0",
-    "@babel/runtime": "7.2.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "23.6.0",
     "git-changelog": "0.1.8",
@@ -68,6 +67,7 @@
     "travis-deploy-once": "^5.0.9"
   },
   "dependencies": {
-    "@babel/polyfill": "7.0.0"
+    "@babel/polyfill": "7.0.0",
+    "@babel/runtime": "7.2.0"
   }
 }


### PR DESCRIPTION
babel runtime is required to execute compiled sources